### PR TITLE
xbc1: verify checksum when decompressing

### DIFF
--- a/xc3_lib/src/error.rs
+++ b/xc3_lib/src/error.rs
@@ -12,4 +12,7 @@ pub enum DecompressStreamError {
 
     #[error("error reading stream data")]
     Binrw(#[from] binrw::Error),
+
+    #[error("checksum verification failed")]
+    Checksum(Vec<u8>),
 }


### PR DESCRIPTION
This adds checksum verification when decoding XBC1 files.  
In the case of a checksum mismatch, the decompressed data is returned to attempt recovery.

I added the error variant to the `DecompressStreamError` enum. Originally, I tried creating an error type specific to Xbc1, but it would have been quite big of a refactor because the more generic error type is referenced in many other places.

I tested this on a local copy of ard-tools, as the xc3_test binary required some graphics-related system dependencies.