### PR TITLE
LAST (.wisty) read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ xc3_lib supports a number of in game formats. All formats support reading. Write
 | [Laft](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/laft.rs) | LAFT | `wifnt` | ✔️ | 
 | [Lagp](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/lagp.rs) | LAGP | `wilay` | ✔️* | 
 | [Laps](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/laps.rs) | LAPS | `wilay` | ✔️* | 
+| [Last](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/last.rs) | LAST | `wisty` | ✔️ | 
 | [Ltpc](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/ltpc.rs) | LTPC | | ✔️ | 
 | [Mibl](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/mibl.rs) | LBIM | `witex`, `witx` | ✔️ | 
 | [Msmd](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/msmd.rs) | DMSM | `wismhd` | ❌ | 

--- a/xc3_lib/src/last.rs
+++ b/xc3_lib/src/last.rs
@@ -1,0 +1,104 @@
+//! Font styles in `.wisty` files.
+//!
+//! # File Paths
+//! Xenoblade DE `.wisty` [Last] are in [Xbc1](crate::xbc1::Xbc1) archives.
+//!
+//! | Game | Versions | File Patterns |
+//! | --- | --- | --- |
+//! | Xenoblade Chronicles 1 DE | 10001 | `menu/font/*.wisty` |
+//! | Xenoblade Chronicles 2 | 10001 | `menu/font/*.wisty` |
+//! | Xenoblade Chronicles 3 | 10001 | `menu/font/*.wisty` |
+
+use crate::{
+    parse_offset32_count32, parse_string_opt_ptr32, parse_string_ptr32, xc3_write_binwrite_impl,
+};
+use bilge::{arbitrary_int::u30, bitsize, prelude::Number, Bitsized, DebugBits, FromBits};
+use binrw::{binread, BinRead, BinWrite};
+use xc3_write::{Xc3Write, Xc3WriteOffsets};
+
+const VERSION: u32 = 10001;
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[binread]
+#[derive(Debug, Xc3Write, Xc3WriteOffsets, PartialEq, Clone)]
+#[br(magic = b"LAST")]
+#[xc3(magic(b"LAST"))]
+#[xc3(align_after(16))]
+pub struct Last {
+    #[br(assert(version == VERSION))]
+    version: u32,
+
+    #[br(temp, restore_position)]
+    offset: u32,
+
+    #[br(parse_with = parse_offset32_count32)]
+    #[xc3(offset_count(u32, u32))]
+    pub styles: Vec<FontStyle>,
+
+    #[br(count = (offset - 16) / 4)]
+    unks: Vec<u32>,
+}
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, BinRead, Xc3Write, Xc3WriteOffsets, PartialEq, Clone)]
+pub struct FontStyle {
+    pub flags: StyleFlags,
+
+    /// The name of this style
+    #[br(parse_with = parse_string_ptr32)]
+    #[xc3(offset(u32))]
+    pub style_name: String,
+
+    /// The name of the font to use
+    #[br(parse_with = parse_string_opt_ptr32)]
+    #[xc3(offset(u32))]
+    pub font_name: Option<String>,
+
+    pub scale_x: f32,
+    pub scale_y: f32,
+
+    /// Always 100.0, no visible changes when edited
+    #[br(assert(unk1 == 100.0))]
+    pub unk1: f32,
+
+    /// Maximum width of a single line.
+    ///
+    /// In XC2, characters that would make the text go past the limit are not displayed.  
+    /// In XCDE and XC3, instead, the text area is stretched to fit the maximum width.
+    pub max_width: u16,
+    /// Maximum lines to display
+    pub max_lines: u16,
+
+    /// Affects space between lines.
+    ///
+    /// For horizontal text, this is added to the glyph height. For vertical text,
+    /// this is added to the glyph width.
+    pub add_line_space: u16,
+    /// Affects space between characters.
+    ///
+    /// For horizontal text, this is added to the glyph width. For vertical text,
+    /// this is added to the glyph height.
+    #[xc3(pad_size_to(6))]
+    #[br(pad_size_to = 6)]
+    pub add_char_space: u16,
+
+    /// Always 4, no visible changes when edited
+    #[br(assert(unk2 == 4))]
+    pub unk2: u32,
+}
+
+#[bitsize(32)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(DebugBits, FromBits, BinRead, BinWrite, PartialEq, Clone, Copy)]
+#[br(map = u32::into)]
+#[bw(map = |&x| u32::from(x))]
+pub struct StyleFlags {
+    /// Most likely. This is unset for some unused styles, but unsetting it does not prevent
+    /// styles from being loaded.
+    pub enabled: bool,
+    /// Prevents glyphs from using their own space data, effectively making the font monospace.
+    pub monospace: bool,
+    pub unk: u30,
+}
+
+xc3_write_binwrite_impl!(StyleFlags);

--- a/xc3_lib/src/lib.rs
+++ b/xc3_lib/src/lib.rs
@@ -66,6 +66,7 @@ pub mod idcm;
 pub mod laft;
 pub mod lagp;
 pub mod laps;
+pub mod last;
 pub mod ltpc;
 pub mod map;
 pub mod mibl;
@@ -473,7 +474,8 @@ file_write_full_impl!(
     idcm::Idcm,
     datasheet::DataSheet,
     wipac::Wipac,
-    laft::Laft
+    laft::Laft,
+    last::Last
 );
 
 #[derive(Debug, Error)]
@@ -545,7 +547,8 @@ file_read_impl!(
     idcm::Idcm,
     datasheet::DataSheet,
     wipac::Wipac,
-    laft::Laft
+    laft::Laft,
+    last::Last
 );
 
 file_read_impl!(

--- a/xc3_test/src/main.rs
+++ b/xc3_test/src/main.rs
@@ -19,6 +19,7 @@ use xc3_lib::{
     laft::Laft,
     lagp::Lagp,
     laps::Laps,
+    last::Last,
     ltpc::Ltpc,
     mibl::Mibl,
     msmd::Msmd,
@@ -96,6 +97,10 @@ struct Cli {
     /// Process LAFT files from .wifnt
     #[arg(long)]
     laft: bool,
+
+    /// Process LAST files from .wisty
+    #[arg(long)]
+    last: bool,
 
     /// Process MTXT files from .catex, .calut, and .caavp
     #[arg(long)]
@@ -245,6 +250,11 @@ fn main() {
     if cli.laft || cli.all {
         println!("Checking Laft files ...");
         check_all(root, &["*.wifnt"], check_laft_data, Endian::Little, cli.rw);
+    }
+
+    if cli.last || cli.all {
+        println!("Checking Last files ...");
+        check_all(root, &["*.wisty"], check_last_data, Endian::Little, cli.rw);
     }
 
     if cli.mtxt || cli.all {
@@ -935,6 +945,26 @@ fn check_laft(laft: Laft, path: &Path, original_bytes: &[u8], check_read_write: 
         laft.write(&mut writer).unwrap();
         if writer.into_inner() != original_bytes {
             println!("Laft read/write not 1:1 for {path:?}");
+        }
+    }
+}
+
+fn check_last_data(
+    data: MaybeXbc1<Last>,
+    path: &Path,
+    original_bytes: &[u8],
+    check_read_write: bool,
+) {
+    check_maybe_xbc1(data, path, check_read_write, original_bytes, check_last);
+}
+
+fn check_last(last: Last, path: &Path, original_bytes: &[u8], check_read_write: bool) {
+    if check_read_write {
+        let mut writer = Cursor::new(Vec::new());
+        last.write(&mut writer).unwrap();
+        if writer.get_ref() != original_bytes {
+            std::fs::write("/tmp/out.wisty", writer.into_inner()).unwrap();
+            println!("Last read/write not 1:1 for {path:?}");
         }
     }
 }


### PR DESCRIPTION
This PR adds support for reading and writing LAST files (.wisty extension).

I don't have an editor for these files, but I've checked for binary compatibility as per your latest commits.

For quick verification, you can edit style `#15` (starting at 0) in `bf3_gb.wisty`. Changes should be reflected in the "(-) INFORMATION" text you see in the title screen.