### PR TITLE
XCX fonts (.fnt) read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ xc3_lib supports a number of in game formats. All formats support reading. Write
 | [Bmn](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/bmn.rs) | BMN | `bmn` | ❌ | 
 | [Dhal](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/dhal.rs) | LAHD | `wilay` | ✔️* | 
 | [Eva](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/eva.rs) | eva | `eva` | ✔️* | 
+| [Fnt](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/fnt.rs) | | `fnt` | ✔️ | 
 | [Laft](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/laft.rs) | LAFT | `wifnt` | ✔️ | 
 | [Lagp](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/lagp.rs) | LAGP | `wilay` | ✔️* | 
 | [Laps](https://github.com/ScanMountGoat/xc3_lib/blob/main/xc3_lib/src/laps.rs) | LAPS | `wilay` | ✔️* | 

--- a/xc3_lib/src/fnt.rs
+++ b/xc3_lib/src/fnt.rs
@@ -24,7 +24,7 @@ pub struct Fnt {
 
     #[br(parse_with = parse_ptr32)]
     #[xc3(offset(u32))]
-    pub font: Font,
+    pub font: XcxFont,
 
     // No problem with sub-cursors here, XCX expects the MTXT footer to end the file
     // (i.e. mtxt size = file_size - textures_offset)
@@ -35,46 +35,67 @@ pub struct Fnt {
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, BinRead, Xc3Write, Xc3WriteOffsets, PartialEq, Clone)]
-pub struct Font {
+pub struct XcxFont {
     pub grid_width: u32,
     pub grid_height: u32,
     glyph_count: u32,
 
+    /// Some sort of threshold, setting it too high makes some of the text not render.  
+    /// Setting it to zero is a safe bet.
     pub unk_1: u32,
+    /// Final width property for glyph rendering.
+    ///
+    /// Glyph indexes use the regular grid dimensions ([`grid_width`] x [`grid_height`]). To render
+    /// the glyph, the game then clips/extends the sprite to this width.
+    ///
+    /// Unlike [`Laft`], glyph-specific x/width does not shift the sprite box (potentially overlapping
+    /// other glyphs), instead it just controls how much whitespace is rendered before and after the glyph.
+    ///
+    /// [`Laft`]: crate::laft::Laft
+    pub subgrid_width: u32,
+    /// No visual differences when changed
     pub unk_2: u32,
-    pub unk_3: u32,
 
     pub font_height: u32,
     pub glyphs_per_row: u32,
     pub num_rows: u32,
 
     #[br(count = glyph_count)]
-    glyphs: Vec<Glyph>,
+    glyphs: Vec<XcxGlyph>,
 }
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, BinRead, Xc3Write, Xc3WriteOffsets, PartialEq, Clone, Copy)]
-pub struct Glyph {
+pub struct XcxGlyph {
+    /// UTF-16 code point, acting as the primary key for this glyph.
+    ///
+    /// Both [`XcxFont::glyphs`] and the grid in the texture sheet must be ordered by this key.
     pub code_utf16: u16,
+    /// Shift-JIS code point, allows duplicates (e.g. unsupported characters share it with a similar
+    /// character) and needs not be a sort key.
     pub code_shift_jis: u16,
+
+    /// X offset relative to the next glyph (higher values result in the glyph getting shifted
+    /// farther to the left)
     pub x_offset: u8,
+    /// Additional whitespace after the glyph
     pub width: u8,
 }
 
-impl Font {
+impl XcxFont {
     /// Returns the registered glyphs, in UTF-16 code point order
-    pub fn glyphs(&self) -> &[Glyph] {
+    pub fn glyphs(&self) -> &[XcxGlyph] {
         &self.glyphs
     }
 
-    pub fn get_glyph_by_utf16(&self, code_utf16: u16) -> Option<&Glyph> {
+    pub fn get_glyph_by_utf16(&self, code_utf16: u16) -> Option<&XcxGlyph> {
         self.glyphs
             .binary_search_by_key(&code_utf16, |g| g.code_utf16)
             .ok()
             .map(|i| &self.glyphs[i])
     }
 
-    pub fn get_glyph_by_shift_jis(&self, code_shift_jis: u16) -> Option<&Glyph> {
+    pub fn get_glyph_by_shift_jis(&self, code_shift_jis: u16) -> Option<&XcxGlyph> {
         self.glyphs
             .iter()
             .find(|g| g.code_shift_jis == code_shift_jis)
@@ -84,7 +105,7 @@ impl Font {
     ///
     /// Duplicate Shift-JIS code points are allowed, while duplicate UTF-16 codes are not. The
     /// function panics if a glyph with the same UTF-16 code point is already registered.
-    pub fn register_glyph(&mut self, glyph: Glyph) {
+    pub fn register_glyph(&mut self, glyph: XcxGlyph) {
         let idx = self
             .glyphs
             .binary_search_by_key(&glyph.code_utf16, |g| g.code_utf16)

--- a/xc3_lib/src/fnt.rs
+++ b/xc3_lib/src/fnt.rs
@@ -1,0 +1,132 @@
+//! Fonts in `.fnt` files.
+//!
+//! # File Paths
+//!
+//! | Game | Versions | File Patterns |
+//! | --- | --- | --- |
+//! | Xenoblade Chronicles X | | `menu/font/**/*.fnt` |
+
+use std::io::{Cursor, SeekFrom};
+
+use crate::{mtxt::Mtxt, parse_ptr32};
+use binrw::{BinRead, BinResult};
+use xc3_write::{Xc3Write, Xc3WriteOffsets};
+
+const VERSION: u32 = 2;
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, BinRead, Xc3Write, PartialEq, Clone)]
+pub struct Fnt {
+    #[br(assert(version == VERSION))]
+    version: u32,
+    #[xc3(shared_offset)]
+    file_size: u32,
+
+    #[br(parse_with = parse_ptr32)]
+    #[xc3(offset(u32))]
+    pub font: Font,
+
+    // No problem with sub-cursors here, XCX expects the MTXT footer to end the file
+    // (i.e. mtxt size = file_size - textures_offset)
+    #[br(parse_with = parse_ptr32_mtxt)]
+    #[xc3(offset(u32), align(4096))]
+    pub textures: Mtxt,
+}
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, BinRead, Xc3Write, Xc3WriteOffsets, PartialEq, Clone)]
+pub struct Font {
+    pub grid_width: u32,
+    pub grid_height: u32,
+    glyph_count: u32,
+
+    pub unk_1: u32,
+    pub unk_2: u32,
+    pub unk_3: u32,
+
+    pub font_height: u32,
+    pub glyphs_per_row: u32,
+    pub num_rows: u32,
+
+    #[br(count = glyph_count)]
+    glyphs: Vec<Glyph>,
+}
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, BinRead, Xc3Write, Xc3WriteOffsets, PartialEq, Clone, Copy)]
+pub struct Glyph {
+    pub code_utf16: u16,
+    pub code_shift_jis: u16,
+    pub x_offset: u8,
+    pub width: u8,
+}
+
+impl Font {
+    /// Returns the registered glyphs, in UTF-16 code point order
+    pub fn glyphs(&self) -> &[Glyph] {
+        &self.glyphs
+    }
+
+    pub fn get_glyph_by_utf16(&self, code_utf16: u16) -> Option<&Glyph> {
+        self.glyphs
+            .binary_search_by_key(&code_utf16, |g| g.code_utf16)
+            .ok()
+            .map(|i| &self.glyphs[i])
+    }
+
+    pub fn get_glyph_by_shift_jis(&self, code_shift_jis: u16) -> Option<&Glyph> {
+        self.glyphs
+            .iter()
+            .find(|g| g.code_shift_jis == code_shift_jis)
+    }
+
+    /// Registers a new glyph.
+    ///
+    /// Duplicate Shift-JIS code points are allowed, while duplicate UTF-16 codes are not. The
+    /// function panics if a glyph with the same UTF-16 code point is already registered.
+    pub fn register_glyph(&mut self, glyph: Glyph) {
+        let idx = self
+            .glyphs
+            .binary_search_by_key(&glyph.code_utf16, |g| g.code_utf16)
+            .expect_err("glyph already registered");
+        self.glyphs.insert(idx, glyph);
+        self.glyph_count += 1;
+    }
+}
+
+impl<'a> Xc3WriteOffsets for FntOffsets<'a> {
+    fn write_offsets<W: std::io::Write + std::io::Seek>(
+        &self,
+        writer: &mut W,
+        base_offset: u64,
+        data_ptr: &mut u64,
+        endian: xc3_write::Endian,
+    ) -> xc3_write::Xc3Result<()> {
+        self.font
+            .write_full(writer, base_offset, data_ptr, endian)?;
+        self.textures
+            .write_full(writer, base_offset, data_ptr, endian)?;
+        // Update file size field with current position after writing the entire file structure
+        self.file_size
+            .write_full(writer, base_offset, data_ptr, endian)?;
+        Ok(())
+    }
+}
+
+fn parse_ptr32_mtxt<T, R, Args>(reader: &mut R, endian: binrw::Endian, args: Args) -> BinResult<T>
+where
+    for<'a> T: BinRead<Args<'a> = Args> + 'static,
+    R: std::io::Read + std::io::Seek,
+    Args: Clone,
+{
+    // Mtxt uses SeekFrom::Start(0), we need to create a sub-cursor
+    let offset = u32::read_options(reader, endian, ())?;
+    let pos = reader.stream_position()?;
+    let mut buf = Vec::new();
+
+    reader.seek(SeekFrom::Start(offset.into()))?;
+    reader.read_to_end(&mut buf)?;
+    reader.seek(SeekFrom::Start(pos))?;
+
+    T::read_options(&mut Cursor::new(buf), endian, args)
+}

--- a/xc3_lib/src/lib.rs
+++ b/xc3_lib/src/lib.rs
@@ -60,6 +60,7 @@ pub mod dhal;
 pub mod efb0;
 pub mod error;
 pub mod eva;
+pub mod fnt;
 pub mod hash;
 pub mod hkt;
 pub mod idcm;
@@ -479,6 +480,8 @@ file_write_full_impl!(
     last::Last
 );
 
+file_write_full_impl!(xc3_write::Endian::Big, fnt::Fnt);
+
 #[derive(Debug, Error)]
 #[error("error reading {path:?}")]
 pub struct ReadFileError {
@@ -558,7 +561,8 @@ file_read_impl!(
     mxmd::legacy::MxmdLegacy,
     bmn::Bmn,
     hkt::Hkt,
-    mths::Mths
+    mths::Mths,
+    fnt::Fnt
 );
 
 macro_rules! xc3_write_binwrite_impl {

--- a/xc3_lib/src/mtxt.rs
+++ b/xc3_lib/src/mtxt.rs
@@ -13,8 +13,11 @@ use std::io::SeekFrom;
 use binrw::{binrw, BinRead, BinWrite};
 use image_dds::{ddsfile::Dds, Surface};
 use thiserror::Error;
+use xc3_write::Xc3Write;
 
 pub use wiiu_swizzle::SwizzleError;
+
+use crate::xc3_write_binwrite_impl;
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, BinWrite, PartialEq, Eq, Clone)]
@@ -315,3 +318,5 @@ impl SurfaceFormat {
         }
     }
 }
+
+xc3_write_binwrite_impl!(Mtxt);

--- a/xc3_tex/src/convert.rs
+++ b/xc3_tex/src/convert.rs
@@ -7,6 +7,7 @@ use xc3_lib::{
     bmn::Bmn,
     dds::DdsExt,
     dhal::Dhal,
+    fnt::Fnt,
     laft::Laft,
     lagp::Lagp,
     laps::Laps,
@@ -31,6 +32,7 @@ pub enum File {
     Camdo(Box<MxmdLegacy>),
     Bmn(Bmn),
     Wifnt(MaybeXbc1<Laft>),
+    XcxFnt(Fnt),
 }
 
 // TODO: Move this to xc3_lib?
@@ -58,6 +60,10 @@ impl File {
             File::Wifnt(laft) => laft_mibl(laft)?
                 .to_dds()
                 .with_context(|| "failed to convert Laft to DDS"),
+            File::XcxFnt(fnt) => fnt
+                .textures
+                .to_dds()
+                .with_context(|| "failed to convert Fnt to DDS"),
             File::Dds(dds) => {
                 // Handle changes in image format while preserving layers and mipmaps.
                 // TODO: dds doesn't implement clone?
@@ -120,6 +126,8 @@ impl File {
             File::Mtxt(mtxt) => Mibl::from_surface(mtxt.to_surface()?)
                 .with_context(|| "failed to convert Mtxt to Mibl"),
             File::Wifnt(laft) => laft_mibl(laft),
+            File::XcxFnt(fnt) => Mibl::from_surface(fnt.textures.to_surface()?)
+                .with_context(|| "failed to convert Fnt to Mibl"),
             File::Dds(dds) => Mibl::from_dds(dds).with_context(|| "failed to create Mibl from DDS"),
             File::Image(image) => {
                 let dds = image_dds::dds_from_image(
@@ -160,6 +168,8 @@ impl File {
                 .with_context(|| "failed to decode Mtxt image"),
             File::Wifnt(laft) => image_dds::image_from_dds(&laft_mibl(laft)?.to_dds()?, 0)
                 .with_context(|| "failed to decode Laft image"),
+            File::XcxFnt(fnt) => image_dds::image_from_dds(&fnt.textures.to_dds()?, 0)
+                .with_context(|| "failed to decode Fnt image"),
             File::Dds(dds) => {
                 image_dds::image_from_dds(dds, 0).with_context(|| "failed to decode DDS")
             }

--- a/xc3_tex/src/main.rs
+++ b/xc3_tex/src/main.rs
@@ -12,6 +12,7 @@ use strum::IntoEnumIterator;
 use xc3_lib::{
     bmn::Bmn,
     dds::DdsExt,
+    fnt::Fnt,
     laft::Laft,
     mibl::Mibl,
     mtxt::Mtxt,
@@ -262,6 +263,9 @@ fn load_input_file(input: &PathBuf) -> anyhow::Result<File> {
         "wifnt" => MaybeXbc1::<Laft>::from_file(input)
             .with_context(|| format!("{input:?} is not a valid .wifnt file"))
             .map(File::Wifnt),
+        "fnt" => Fnt::from_file(input)
+            .with_context(|| format!("{input:?} is not a valid .fnt file"))
+            .map(File::XcxFnt),
         _ => {
             // Assume other formats are image formats.
             let image = image::open(input)


### PR DESCRIPTION
This PR adds support for reading and writing Xenoblade X font files (.fnt, no magic).

These files seem to be a slimmed-down version of LAFT, and they use `Mtxt` texture blocks.  
I don't have a font tool for these, but I've added texture extraction and checks for binary identity.